### PR TITLE
fix: address all confirmed security, performance, and DX audit findings

### DIFF
--- a/src/dry2/accordion.js
+++ b/src/dry2/accordion.js
@@ -200,18 +200,6 @@ class DryAccordion extends BaseElement {
     this._accordionEl = container;
   }
 
-  /**
-   * Set Alpine.js data on container element safely
-   */
-  /**
-   * Set Alpine.js data on container element safely
-   */
-  /**
-   * Set Alpine.js data on container element safely
-   */
-  /**
-   * Set Alpine.js data on container element safely
-   */
   _setAlpineData(container) {
     const openItems = this._accordionState.getOpenItems();
     const multiple = this._accordionState.multiple;
@@ -453,27 +441,28 @@ class DryAccordion extends BaseElement {
   // Public API Methods with improved error handling
   openItem(itemId) {
     if (!this._validateItemId(itemId)) return;
-    
     const alpineData = this._getAlpineDataSecurely();
-    if (alpineData && !alpineData.disabled && !alpineData.isOpen(itemId)) {
+    if (alpineData && !alpineData.disabled &&
+        typeof alpineData.isOpen === 'function' && !alpineData.isOpen(itemId) &&
+        typeof alpineData.toggle === 'function') {
       alpineData.toggle(itemId);
     }
   }
 
   closeItem(itemId) {
     if (!this._validateItemId(itemId)) return;
-    
     const alpineData = this._getAlpineDataSecurely();
-    if (alpineData && alpineData.isOpen(itemId)) {
+    if (alpineData &&
+        typeof alpineData.isOpen === 'function' && alpineData.isOpen(itemId) &&
+        typeof alpineData.toggle === 'function') {
       alpineData.toggle(itemId);
     }
   }
 
   toggleItem(itemId) {
     if (!this._validateItemId(itemId)) return;
-    
     const alpineData = this._getAlpineDataSecurely();
-    if (alpineData && !alpineData.disabled) {
+    if (alpineData && !alpineData.disabled && typeof alpineData.toggle === 'function') {
       alpineData.toggle(itemId);
     }
   }

--- a/src/dry2/avatar.js
+++ b/src/dry2/avatar.js
@@ -21,12 +21,14 @@ class DryAvatar extends BaseElement {
   }
 
   _render(originalContent) {
-    const src = this.src;
-    const name = this.name;
-    const initials = this.initials || this._generateInitials(name);
-    const size = this.size;
-    const shape = this.shape;
-    const alt = this.alt || `Avatar for ${name || 'user'}`;
+    const src = this._escapeForJs(this.src);
+    const name = this._escapeForJs(this.name);
+    const initials = this._escapeForJs(this.initials || this._generateInitials(this.name));
+    const validSizes = ['xs', 'sm', 'md', 'lg', 'xl'];
+    const size = validSizes.includes(this.size) ? this.size : 'md';
+    const validShapes = ['circle', 'square', 'rounded'];
+    const shape = validShapes.includes(this.shape) ? this.shape : 'circle';
+    const alt = this._escapeForJs(this.alt || `Avatar for ${this.name || 'user'}`);
 
     this.innerHTML = `
             <div x-data="{

--- a/src/dry2/base.js
+++ b/src/dry2/base.js
@@ -8,6 +8,8 @@ class BaseElement extends HTMLElement {
     this._isInitialized = false;
     this._componentData = {};
     this._originalContent = null;
+    this._pendingTimeouts = [];
+    this._childrenObserver = null;
   }
 
   connectedCallback() {
@@ -56,32 +58,35 @@ class BaseElement extends HTMLElement {
    */
   _waitForChildrenAndInitialize() {
     const observer = new MutationObserver((mutations) => {
-      // Check if children were added
       const hasChildren = mutations.some(mutation => mutation.addedNodes.length > 0);
       if (hasChildren && this.children.length > 0) {
         observer.disconnect();
+        this._childrenObserver = null;
         this._originalContent = this.innerHTML;
         this._waitForAlpineAndInitialize();
       }
     });
 
+    this._childrenObserver = observer;
     observer.observe(this, { childList: true, subtree: true });
 
-    // Fallback: if children are already present, initialize immediately
-    setTimeout(() => {
+    const t1 = setTimeout(() => {
       if (this.children.length > 0) {
         observer.disconnect();
+        this._childrenObserver = null;
         this._originalContent = this.innerHTML;
         this._waitForAlpineAndInitialize();
       } else {
-        // No children found, try again with longer delay
-        setTimeout(() => {
+        const t2 = setTimeout(() => {
           observer.disconnect();
+          this._childrenObserver = null;
           this._originalContent = this.innerHTML;
           this._waitForAlpineAndInitialize();
         }, 500);
+        this._pendingTimeouts.push(t2);
       }
     }, 100);
+    this._pendingTimeouts.push(t1);
   }
 
   /**
@@ -330,16 +335,38 @@ class BaseElement extends HTMLElement {
     this._handleAttributeChange(name, oldValue, newValue);
   }
 
-  /**
-   * Common cleanup method - override in child classes if needed
-   */
+  _escapeHtml(str) {
+    if (typeof str !== 'string') return '';
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  _escapeForJs(str) {
+    if (typeof str !== 'string') return '';
+    return str
+      .replace(/\\/g, '\\\\')
+      .replace(/'/g, "\\'")
+      .replace(/"/g, '\\"')
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '\\r')
+      .replace(/\t/g, '\\t');
+  }
+
   disconnectedCallback() {
-    // Cleanup logic can be added here
+    this._pendingTimeouts.forEach(id => clearTimeout(id));
+    this._pendingTimeouts = [];
+    if (this._childrenObserver) {
+      this._childrenObserver.disconnect();
+      this._childrenObserver = null;
+    }
   }
 }
 
 // Make BaseElement globally available
-window.BaseElement = BaseElement; 
+window.BaseElement = BaseElement;
+window.DRY2 = window.DRY2 || {};
+window.DRY2.BaseElement = BaseElement;
 
 /**
  * Alpine.js Utilities for DRY2 Components

--- a/src/dry2/chat-bubble.js
+++ b/src/dry2/chat-bubble.js
@@ -28,7 +28,16 @@ class DryChatBubble extends BaseElement {
   }
 
   _extractContent() {
-    return this.innerHTML.trim();
+    return this._sanitizeContent(this.innerHTML.trim());
+  }
+
+  _sanitizeContent(content) {
+    if (typeof content !== 'string') return '';
+    return content
+      .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+      .replace(/on\w+\s*=\s*"[^"]*"/gi, '')
+      .replace(/on\w+\s*=\s*'[^']*'/gi, '')
+      .replace(/javascript:/gi, '');
   }
 
   _render() {

--- a/src/dry2/drawer.js
+++ b/src/dry2/drawer.js
@@ -22,19 +22,19 @@ class DryDrawer extends BaseElement {
   }
 
   render() {
-    const headerContent = this.querySelector('[slot="header"]')?.innerHTML || this.headerContent;
+    const headerSlotEl = this.querySelector('[slot="header"]');
     const contentSlot = this.querySelector('[slot="content"]')?.outerHTML || '<slot name="content"></slot>';
 
     this.innerHTML = `
         <div class="drawer-container">
             <button type="button" class="trigger-button ${this.buttonClass}">
-                ${this.triggerContent}
+                ${this._escapeHtml(this.triggerContent)}
             </button>
             <div class="drawer-wrapper fixed inset-0 z-50 pointer-events-none">
                 <div class="drawer-backdrop fixed inset-0 bg-black bg-opacity-50 transition-opacity duration-300 ease-in-out opacity-0 pointer-events-none ${this.backdropClass}"></div>
                 <div class="drawer fixed ${this.position === 'left' ? 'left-0 -translate-x-full' : 'right-0 translate-x-full'} top-0 h-full transition-transform duration-300 ease-in-out pointer-events-auto shadow-xl ${this.drawerClass}">
                     <div class="drawer-header flex items-center justify-between p-4 border-b ${this.headerClass}">
-                        <div class="drawer-title">${headerContent}</div>
+                        <div class="drawer-title"></div>
                         <svg viewBox="0 0 24 24" class="drawer-close cursor-pointer h-6 w-6 text-gray-500 hover:text-gray-700">
                             <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
                         </svg>
@@ -46,6 +46,14 @@ class DryDrawer extends BaseElement {
             </div>
         </div>
         `;
+
+    // Set header title safely via DOM to avoid HTML injection
+    const titleEl = this.querySelector('.drawer-title');
+    if (headerSlotEl) {
+      titleEl.appendChild(headerSlotEl.cloneNode(true));
+    } else {
+      titleEl.textContent = this.headerContent;
+    }
   }
 
   attachEventListeners() {
@@ -190,24 +198,25 @@ class AjaxDrawer extends BaseElement {
   }
 
   render() {
-    const headerContent = this.querySelector('[slot="header"]')?.innerHTML || this.headerContent;
+    const headerSlotEl = this.querySelector('[slot="header"]');
+    const contentId = this.contentId;
 
     this.innerHTML = `
         <div class="drawer-container">
-            <button type="button" class="trigger-button ${this.buttonClass}" hx-get="${this.url}" hx-trigger="${this.triggerType}" hx-target="#${this.contentId}">
-                ${this.triggerContent}
+            <button type="button" class="trigger-button ${this.buttonClass}">
+                ${this._escapeHtml(this.triggerContent)}
             </button>
             <div class="drawer-wrapper fixed inset-0 z-50 pointer-events-none">
                 <div class="drawer-backdrop fixed inset-0 bg-black bg-opacity-50 transition-opacity duration-300 ease-in-out opacity-0 pointer-events-none ${this.backdropClass}"></div>
                 <div class="drawer fixed ${this.position === 'left' ? 'left-0 -translate-x-full' : 'right-0 translate-x-full'} top-0 h-full transition-transform duration-300 ease-in-out pointer-events-auto shadow-xl ${this.drawerClass}">
                     <div class="drawer-header flex items-center justify-between p-4 border-b ${this.headerClass}">
-                        <div class="drawer-title">${headerContent}</div>
+                        <div class="drawer-title"></div>
                         <svg viewBox="0 0 24 24" class="drawer-close cursor-pointer h-6 w-6 text-gray-500 hover:text-gray-700">
                             <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
                         </svg>
                     </div>
                     <div class="drawer-content p-4">
-                        <div id="${this.contentId}" class="drawer-ajax-content"></div>
+                        <div class="drawer-ajax-content"></div>
                         <div class="drawer-loading hidden flex justify-center items-center p-8">
                             <svg class="animate-spin -ml-1 mr-3 h-8 w-8 text-blue-500" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -223,6 +232,26 @@ class AjaxDrawer extends BaseElement {
             </div>
         </div>
         `;
+
+    // Set attributes via DOM to avoid HTML injection
+    const btn = this.querySelector('.trigger-button');
+    if (btn) {
+      btn.setAttribute('hx-get', this.url);
+      btn.setAttribute('hx-trigger', this.triggerType);
+      btn.setAttribute('hx-target', `#${contentId}`);
+    }
+    const ajaxContent = this.querySelector('.drawer-ajax-content');
+    if (ajaxContent) {
+      ajaxContent.id = contentId;
+    }
+    const titleEl = this.querySelector('.drawer-title');
+    if (titleEl) {
+      if (headerSlotEl) {
+        titleEl.appendChild(headerSlotEl.cloneNode(true));
+      } else {
+        titleEl.textContent = this.headerContent;
+      }
+    }
   }
 
   attachEventListeners() {
@@ -233,7 +262,7 @@ class AjaxDrawer extends BaseElement {
     this.drawerWrapper = this.querySelector('.drawer-wrapper');
     this.loadingElement = this.querySelector('.drawer-loading');
     this.errorElement = this.querySelector('.drawer-error');
-    this.contentElement = this.querySelector(`#${this.contentId}`);
+    this.contentElement = this.querySelector('.drawer-ajax-content');
 
     // Store bound methods
     this.boundClose = this.close.bind(this);
@@ -399,7 +428,11 @@ class AjaxDrawer extends BaseElement {
   }
 
   get contentId() {
-    return this._getAttributeWithDefault('content-id', `drawer-content-${Math.floor(Math.random() * 10000)}`);
+    if (!this._contentId) {
+      this._contentId = this.getAttribute('content-id') ||
+        `drawer-content-${typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2)}`;
+    }
+    return this._contentId;
   }
 }
 

--- a/src/dry2/select.js
+++ b/src/dry2/select.js
@@ -136,7 +136,10 @@ class DrySelect extends BaseElement {
            @keydown.escape="isOpen = false; updateSearchDisplay()">
            
         <!-- Main Button -->
-        <div 
+        <div
+            role="combobox"
+            :aria-expanded="isOpen"
+            aria-haspopup="listbox"
             class="${buttonClass} ${isDisabled ? 'opacity-50 cursor-not-allowed' : ''}"
             @mousedown="isClickingButton = true"
             @mouseup="setTimeout(() => isClickingButton = false, 10)"
@@ -200,7 +203,7 @@ class DrySelect extends BaseElement {
         </div>
         
         <!-- Dropdown -->
-        <div 
+        <div
             x-show="isOpen"
             x-transition:enter="transition ease-out duration-300"
             x-transition:enter-start="transform opacity-0 scale-95"
@@ -208,6 +211,8 @@ class DrySelect extends BaseElement {
             x-transition:leave="transition ease-in duration-200"
             x-transition:leave-start="transform opacity-100 scale-100"
             x-transition:leave-end="transform opacity-0 scale-95"
+            role="listbox"
+            :aria-label="placeholder"
             class="${dropdownClass}"
             style="max-height: ${maxHeight}">
             
@@ -226,7 +231,9 @@ class DrySelect extends BaseElement {
             </template>
             
             <template x-for="(option, index) in availableOptions" :key="option.value">
-                <div 
+                <div
+                    role="option"
+                    :aria-selected="selectedValues.includes(option.value)"
                     class="px-3 py-2 cursor-pointer hover:bg-blue-50 hover:text-blue-700 transition-colors duration-150 flex items-center justify-between"
                     :class="{
                         'bg-blue-50': index === focusedIndex,

--- a/src/dry2/toast.js
+++ b/src/dry2/toast.js
@@ -291,5 +291,7 @@ class Toast {
 
 // Make Toast available globally
 window.Toast = Toast;
+window.DRY2 = window.DRY2 || {};
+window.DRY2.Toast = Toast;
 
 customElements.define('dry-toast', DryToast);

--- a/tests/unit/components/security-and-lifecycle.test.js
+++ b/tests/unit/components/security-and-lifecycle.test.js
@@ -1,0 +1,285 @@
+import '../setup.js';
+
+describe('Security and Lifecycle Issues', () => {
+  beforeEach(() => { cleanupDOM(); });
+  afterEach(() => { cleanupDOM(); });
+
+  // ── C1: avatar.js XSS via x-data interpolation ─────────────────────────────
+  describe('C1: DryAvatar XSS Prevention', () => {
+    before(async () => {
+      await import('../../../src/dry2/avatar.js');
+    });
+
+    it('should expose _escapeForJs helper', () => {
+      const avatar = document.createElement('dry-avatar');
+      expect(typeof avatar._escapeForJs).to.equal('function');
+    });
+
+    it('should not allow single-quote injection in name attribute to break x-data', () => {
+      const avatar = document.createElement('dry-avatar');
+      avatar.setAttribute('name', "'; alert('xss'); let x='");
+      document.body.appendChild(avatar);
+
+      const xDataEl = avatar.querySelector('[x-data]');
+      if (xDataEl) {
+        const xData = xDataEl.getAttribute('x-data');
+        // Unescaped ' followed by ; would allow JS breakout — escaped version has \' which is safe
+        expect(xData).to.not.match(/(?<!\\)'; alert\(/);
+      }
+    });
+
+    it('should not allow injection via src attribute in x-data', () => {
+      const avatar = document.createElement('dry-avatar');
+      avatar.setAttribute('src', "'+alert(1)+'");
+      document.body.appendChild(avatar);
+
+      const xDataEl = avatar.querySelector('[x-data]');
+      if (xDataEl) {
+        const xData = xDataEl.getAttribute('x-data');
+        // Unescaped '+alert(1)+' would concatenate out of the string
+        expect(xData).to.not.match(/(?<!\\)'\+alert\(1\)\+'/);
+      }
+    });
+
+    it('should not allow injection via alt attribute in x-data', () => {
+      const avatar = document.createElement('dry-avatar');
+      avatar.setAttribute('alt', "'; window.__c1 = true; let z='");
+      document.body.appendChild(avatar);
+
+      const xDataEl = avatar.querySelector('[x-data]');
+      if (xDataEl) {
+        const xData = xDataEl.getAttribute('x-data');
+        expect(xData).to.not.match(/(?<!\\)'; window\.__c1/);
+      }
+    });
+  });
+
+  // ── C2: drawer.js HTML injection via innerHTML template literals ─────────────
+  describe('C2: DryDrawer HTML Injection Prevention', () => {
+    before(async () => {
+      await import('../../../src/dry2/drawer.js');
+    });
+
+    it('should not render raw script tags from trigger-content attribute', () => {
+      const drawer = document.createElement('dry-drawer');
+      drawer.setAttribute('trigger-content', '<script>window.__c2a = true;</script>Open');
+      document.body.appendChild(drawer);
+
+      const button = drawer.querySelector('.trigger-button');
+      if (button) {
+        expect(button.innerHTML).to.not.include('<script>');
+        expect(button.textContent).to.include('Open');
+      }
+    });
+
+    it('should not render raw script tags from header-content attribute', () => {
+      const drawer = document.createElement('dry-drawer');
+      drawer.setAttribute('header-content', '<script>window.__c2b = true;</script>Title');
+      document.body.appendChild(drawer);
+
+      const title = drawer.querySelector('.drawer-title');
+      if (title) {
+        expect(title.innerHTML).to.not.include('<script>');
+      }
+    });
+
+    it('should not allow inline event handler injection via trigger-content', () => {
+      const drawer = document.createElement('dry-drawer');
+      drawer.setAttribute('trigger-content', '<img src=x onerror="window.__c2c=true">');
+      document.body.appendChild(drawer);
+
+      const button = drawer.querySelector('.trigger-button');
+      if (button) {
+        // No real <img> element should be injected — only escaped text
+        expect(button.querySelector('img')).to.be.null;
+      }
+    });
+
+    it('AjaxDrawer: url attribute should not allow HTML attribute injection', () => {
+      const drawer = document.createElement('ajax-drawer');
+      drawer.setAttribute('url', '/api/data');
+      document.body.appendChild(drawer);
+
+      const button = drawer.querySelector('.trigger-button');
+      if (button) {
+        const hxGet = button.getAttribute('hx-get');
+        expect(hxGet).to.equal('/api/data');
+      }
+    });
+  });
+
+  // ── C3: chat-bubble.js x-html of unsanitized slot content ───────────────────
+  describe('C3: DryChatBubble Content Sanitization', () => {
+    before(async () => {
+      await import('../../../src/dry2/chat-bubble.js');
+    });
+
+    it('should strip script tags from slot content before storing in _chatData', () => {
+      const bubble = document.createElement('dry-chat-bubble');
+      bubble.innerHTML = '<script>window.__c3a = true;</script>Hello';
+      document.body.appendChild(bubble);
+
+      expect(bubble._chatData).to.exist;
+      expect(bubble._chatData.content).to.not.include('<script>');
+    });
+
+    it('should strip inline event handlers from slot content', () => {
+      const bubble = document.createElement('dry-chat-bubble');
+      bubble.innerHTML = '<img src=x onerror="window.__c3b=true">Hello';
+      document.body.appendChild(bubble);
+
+      expect(bubble._chatData.content).to.not.include('onerror=');
+    });
+
+    it('should preserve safe formatting HTML like <strong> and <em>', () => {
+      const bubble = document.createElement('dry-chat-bubble');
+      bubble.innerHTML = '<strong>Hello</strong> <em>world</em>';
+      document.body.appendChild(bubble);
+
+      expect(bubble._chatData.content).to.include('strong');
+      expect(bubble._chatData.content).to.include('em');
+    });
+  });
+
+  // ── M1+M2: BaseElement lifecycle — timeout and observer cleanup ──────────────
+  describe('M1+M2: BaseElement Lifecycle Cleanup', () => {
+    let tagName;
+
+    before(() => {
+      // Register a minimal test element — BaseElement itself can't be instantiated
+      tagName = `test-lifecycle-el-${Date.now()}`;
+      class TestLifecycleEl extends BaseElement {}
+      customElements.define(tagName, TestLifecycleEl);
+    });
+
+    it('should initialise _pendingTimeouts as an empty array', () => {
+      const el = document.createElement(tagName);
+      expect(el._pendingTimeouts).to.be.an('array');
+      expect(el._pendingTimeouts).to.have.length(0);
+    });
+
+    it('should initialise _childrenObserver as null', () => {
+      const el = document.createElement(tagName);
+      expect(el._childrenObserver).to.equal(null);
+    });
+
+    it('disconnectedCallback should clear all pending timeouts', (done) => {
+      let fired = false;
+      const el = document.createElement(tagName);
+
+      const id = setTimeout(() => { fired = true; }, 150);
+      el._pendingTimeouts = [id];
+
+      el.disconnectedCallback();
+
+      setTimeout(() => {
+        expect(fired).to.be.false;
+        done();
+      }, 300);
+    });
+
+    it('disconnectedCallback should disconnect a stored MutationObserver', () => {
+      const el = document.createElement(tagName);
+      let disconnected = false;
+      el._childrenObserver = { disconnect: () => { disconnected = true; } };
+
+      el.disconnectedCallback();
+
+      expect(disconnected).to.be.true;
+      expect(el._childrenObserver).to.equal(null);
+    });
+  });
+
+  // ── M3: accordion.js null safety on alpineData methods ──────────────────────
+  describe('M3: Accordion Null Safety', () => {
+    before(async () => {
+      await import('../../../src/dry2/accordion.js');
+    });
+
+    it('openItem should not throw when alpineData.isOpen is not a function', () => {
+      const accordion = document.createElement('dry-accordion');
+      document.body.appendChild(accordion);
+
+      accordion._getAlpineDataSecurely = () => ({
+        disabled: false,
+        isOpen: 'not-a-function',
+        toggle: () => {}
+      });
+
+      expect(() => accordion.openItem('item-0')).to.not.throw();
+    });
+
+    it('closeItem should not throw when alpineData.isOpen is not a function', () => {
+      const accordion = document.createElement('dry-accordion');
+      document.body.appendChild(accordion);
+
+      accordion._getAlpineDataSecurely = () => ({
+        disabled: false,
+        isOpen: null,
+        toggle: () => {}
+      });
+
+      expect(() => accordion.closeItem('item-0')).to.not.throw();
+    });
+
+    it('toggleItem should not throw when alpineData.toggle is not a function', () => {
+      const accordion = document.createElement('dry-accordion');
+      document.body.appendChild(accordion);
+
+      accordion._getAlpineDataSecurely = () => ({
+        disabled: false,
+        isOpen: () => false,
+        toggle: 'not-a-function'
+      });
+
+      expect(() => accordion.toggleItem('item-0')).to.not.throw();
+    });
+  });
+
+  // ── N1: window.DRY2 namespace ────────────────────────────────────────────────
+  describe('N1: DRY2 Namespace', () => {
+    it('window.DRY2 should be an object', () => {
+      expect(window.DRY2).to.be.an('object');
+    });
+
+    it('window.DRY2.BaseElement should be the BaseElement class', () => {
+      expect(window.DRY2.BaseElement).to.exist;
+    });
+
+    it('window.DRY2.Toast should exist after toast.js is imported', async () => {
+      await import('../../../src/dry2/toast.js');
+      expect(window.DRY2.Toast).to.exist;
+    });
+  });
+
+  // ── N2: select.js ARIA roles ─────────────────────────────────────────────────
+  describe('N2: DrySelect ARIA Roles', () => {
+    before(async () => {
+      await import('../../../src/dry2/select.js');
+    });
+
+    it('rendered HTML should include role="listbox" on the dropdown container', () => {
+      const select = document.createElement('dry-select');
+      select.innerHTML = '<option value="a">Option A</option><option value="b">Option B</option>';
+      document.body.appendChild(select);
+
+      expect(select.innerHTML).to.include('role="listbox"');
+    });
+
+    it('rendered HTML should include role="option" on each option row', () => {
+      const select = document.createElement('dry-select');
+      select.innerHTML = '<option value="a">Option A</option>';
+      document.body.appendChild(select);
+
+      expect(select.innerHTML).to.include('role="option"');
+    });
+
+    it('rendered HTML should include aria-expanded on the trigger button area', () => {
+      const select = document.createElement('dry-select');
+      select.innerHTML = '<option value="a">Option A</option>';
+      document.body.appendChild(select);
+
+      expect(select.innerHTML).to.include('aria-expanded');
+    });
+  });
+});

--- a/tests/unit/setup.js
+++ b/tests/unit/setup.js
@@ -11,7 +11,12 @@ const dom = new JSDOM('<!DOCTYPE html><html><head></head><body></body></html>', 
 // Make DOM available globally
 global.window = dom.window;
 global.document = dom.window.document;
-global.navigator = dom.window.navigator;
+// In Node 22+, navigator is a read-only getter; use defineProperty to override
+try {
+  global.navigator = dom.window.navigator;
+} catch (_) {
+  Object.defineProperty(global, 'navigator', { value: dom.window.navigator, writable: true, configurable: true });
+}
 global.HTMLElement = dom.window.HTMLElement;
 global.customElements = dom.window.customElements;
 global.CustomEvent = dom.window.CustomEvent;
@@ -138,6 +143,8 @@ class BaseElement extends HTMLElement {
     this._isInitialized = false;
     this._componentData = {};
     this._originalContent = null;
+    this._pendingTimeouts = [];
+    this._childrenObserver = null;
   }
 
   connectedCallback() {
@@ -148,18 +155,16 @@ class BaseElement extends HTMLElement {
   }
 
   _waitForAlpineAndInitialize() {
-    // For testing, skip Alpine.js wait and initialize immediately
     this._initializeComponent();
   }
 
   _waitForChildrenAndInitialize() {
-    // For testing, initialize immediately
     this._initializeComponent();
   }
 
-  _initializeComponent() {
-    // To be implemented by child classes
-  }
+  _ensureAlpineProcessing() {}
+
+  _initializeComponent() {}
 
   _extractContent() {
     return this.textContent.trim();
@@ -173,9 +178,22 @@ class BaseElement extends HTMLElement {
     return this.getAttribute(name) || defaultValue;
   }
 
+  _getNumericAttribute(name, defaultValue = 0) {
+    const value = this.getAttribute(name);
+    return value !== null ? parseInt(value, 10) || defaultValue : defaultValue;
+  }
+
   _setAttribute(name, value) {
     if (value !== null && value !== undefined && value !== '') {
       this.setAttribute(name, value);
+    } else {
+      this.removeAttribute(name);
+    }
+  }
+
+  _setNumericAttribute(name, value) {
+    if (typeof value === 'number' && !isNaN(value)) {
+      this.setAttribute(name, value.toString());
     } else {
       this.removeAttribute(name);
     }
@@ -193,6 +211,19 @@ class BaseElement extends HTMLElement {
     }
   }
 
+  _dispatchEvent(eventName, detail = {}) {
+    const event = new CustomEvent(eventName, { detail, bubbles: true, cancelable: true });
+    this.dispatchEvent(event);
+  }
+
+  _getAlpineData() {
+    const el = this.querySelector('[x-data]');
+    if (el && window.Alpine) {
+      return el._x_dataStack?.[0] || el.__x?.$data || null;
+    }
+    return null;
+  }
+
   _handleAttributeChange(name, oldValue, newValue) {
     if (oldValue !== newValue && this._isInitialized) {
       this._render && this._render();
@@ -205,22 +236,48 @@ class BaseElement extends HTMLElement {
   }
 
   _extractSlotContent(selector) {
-    // Mock slot content extraction
     if (!selector) {
       return this.innerHTML || '';
     }
-    
     const element = this.querySelector(selector);
     return element ? element.innerHTML : '';
   }
 
+  _escapeHtml(str) {
+    if (typeof str !== 'string') return '';
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  _escapeForJs(str) {
+    if (typeof str !== 'string') return '';
+    return str
+      .replace(/\\/g, '\\\\')
+      .replace(/'/g, "\\'")
+      .replace(/"/g, '\\"')
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '\\r')
+      .replace(/\t/g, '\\t');
+  }
+
   disconnectedCallback() {
-    // Cleanup logic
+    this._pendingTimeouts.forEach(id => clearTimeout(id));
+    this._pendingTimeouts = [];
+    if (this._childrenObserver) {
+      this._childrenObserver.disconnect();
+      this._childrenObserver = null;
+    }
   }
 }
 
 // Make BaseElement globally available
 global.BaseElement = BaseElement;
 global.window.BaseElement = BaseElement;
+
+// Initialise DRY2 namespace
+global.window.DRY2 = global.window.DRY2 || {};
+global.window.DRY2.BaseElement = BaseElement;
+global.DRY2 = global.window.DRY2;
 
 console.log('Test environment setup complete');


### PR DESCRIPTION
Security (Critical/Major):
- avatar.js: escape all string attributes via _escapeForJs() before
  interpolation into Alpine x-data to prevent JS injection (C1)
- drawer.js: escape trigger/header content via _escapeHtml(); set HTMX
  attributes via DOM setAttribute() to prevent HTML injection (C2)
- chat-bubble.js: sanitize slot content before storing in _chatData to
  strip <script> tags and inline event handlers before x-html renders it (C3)

Performance / Stability (Major):
- base.js: track setTimeout IDs in _pendingTimeouts[] and store the
  MutationObserver in _childrenObserver; disconnectedCallback() now
  clears all pending timeouts and disconnects the observer (M1+M2)
- accordion.js: guard openItem/closeItem/toggleItem with typeof checks
  before calling alpineData.isOpen/toggle to prevent TypeError when
  Alpine partial-init returns non-function values (M3)

Minor / Nit:
- accordion.js: remove four duplicate JSDoc blocks stacked on _setAlpineData (N4)
- select.js: add role="listbox" on dropdown, role="option" on each row,
  and role="combobox" + aria-expanded on trigger for WCAG compliance (N2)
- toast.js: expose Toast under window.DRY2.Toast namespace (N1)
- base.js: initialise window.DRY2 namespace and set DRY2.BaseElement (N1)
- drawer.js: replace Math.random() ID with crypto.randomUUID() fallback (N2)

Test infrastructure:
- tests/unit/setup.js: fix Node 22 compatibility (navigator read-only
  getter); add missing mock methods (_dispatchEvent, _escapeHtml,
  _escapeForJs, _getNumericAttribute, etc.); add _pendingTimeouts and
  _childrenObserver lifecycle contract to mock BaseElement
- tests/unit/components/security-and-lifecycle.test.js: 24 new TDD tests
  covering every confirmed finding (all green)

https://claude.ai/code/session_01KqLy9ax1rwRZybrRC6VCPa